### PR TITLE
fix: senders store in array_annotations dictionary

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: psf/black@stable
       with:
         options: "--check --verbose"
-        version: "24.1.1"
+        version: "25.1.0"

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -17,4 +17,4 @@ jobs:
           sudo apt install openmpi-bin libopenmpi-dev
       # Install dependencies for proper 1st/2nd/3rd party import sorting
       - run: pip install -e .[parallel]
-      - uses: isort/isort-action@v1.1.0
+      - uses: isort/isort-action@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ default_install_hook_types:
   - commit-msg
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # bsb-arbor
 
-bsb-nest is a plugin of the [BSB](https://github.com/dbbs-lab/bsb) (see also 
+bsb-arbor is a plugin of the [BSB](https://github.com/dbbs-lab/bsb) (see also 
 [bsb-core](https://github.com/dbbs-lab/bsb-core)). 
 It contains the interfaces and tools to simulate BSB circuit with the 
 [Arbor simulator](https://arbor-sim.org/).

--- a/bsb_arbor/adapter.py
+++ b/bsb_arbor/adapter.py
@@ -7,7 +7,6 @@ import arbor
 import numpy as np
 from arbor import units as U
 from bsb import (
-    MPI,
     AdapterError,
     Chunk,
     SimulationData,
@@ -281,27 +280,15 @@ class ArborRecipe(arbor.recipe):
 
 
 class ArborAdapter(SimulatorAdapter):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, comm=None):
+        super().__init__(comm)
         self.simdata: typing.Dict["ArborSimulation", "SimulationData"] = {}
 
-    def get_rank(self):
-        return MPI.get_rank()
-
-    def get_size(self):
-        return MPI.get_size()
-
-    def broadcast(self, data, root=0):
-        return MPI.bcast(data, root)
-
-    def barrier(self):
-        return MPI.barrier()
-
-    def prepare(self, simulation: "ArborSimulation", comm=None):
+    def prepare(self, simulation: "ArborSimulation"):
         simdata = self._create_simdata(simulation)
         try:
             context = arbor.context(arbor.proc_allocation(threads=simulation.threads))
-            if MPI.get_size() > 1:
+            if self.comm.get_size() > 1:
                 if not arbor.config()["mpi4py"]:
                     warn(
                         f"Arbor does not seem to be built with MPI support, running"
@@ -310,7 +297,7 @@ class ArborAdapter(SimulatorAdapter):
                 else:
                     context = arbor.context(
                         arbor.proc_allocation(threads=simulation.threads),
-                        mpi=comm or MPI.get_communicator(),
+                        mpi=self.comm.get_communicator(),
                     )
             if simulation.profiling:
                 if arbor.config()["profiling"]:
@@ -342,7 +329,7 @@ class ArborAdapter(SimulatorAdapter):
 
     def prepare_samples(self, simulation, simdata):
         for device in simulation.devices.values():
-            device.prepare_samples(simdata)
+            device.prepare_samples(simdata, comm=self.comm)
 
     def run(self, *simulations):
         if len(simulations) != 1:
@@ -358,7 +345,7 @@ class ArborAdapter(SimulatorAdapter):
                 f"Can't run unprepared simulation '{simulation.name}'"
             ) from None
         try:
-            if not MPI.get_rank():
+            if not self.comm.get_rank():
                 arbor_sim.record(arbor.spike_recording.all)
 
             start = time.time()
@@ -431,14 +418,14 @@ class ArborAdapter(SimulatorAdapter):
 
     def _assign_chunks(self, simulation, simdata):
         chunk_stats = simulation.scaffold.storage.get_chunk_stats()
-        size = MPI.get_size()
+        size = self.comm.get_size()
         all_chunks = [Chunk.from_id(int(chunk), None) for chunk in chunk_stats.keys()]
         simdata.node_chunk_alloc = [all_chunks[rank::size] for rank in range(0, size)]
         simdata.chunk_node_map = {}
         for node, chunks in enumerate(simdata.node_chunk_alloc):
             for chunk in chunks:
                 simdata.chunk_node_map[chunk] = node
-        simdata.chunks = simdata.node_chunk_alloc[MPI.get_rank()]
+        simdata.chunks = simdata.node_chunk_alloc[self.comm.get_rank()]
 
 
 def _all_bools(arr):

--- a/bsb_arbor/device.py
+++ b/bsb_arbor/device.py
@@ -19,7 +19,7 @@ class ArborDevice(DeviceModel):
     def register_probe_id(self, gid, tag):
         self._probe_ids.append((gid, tag))
 
-    def prepare_samples(self, simdata):
+    def prepare_samples(self, simdata, comm):
         self._handles = [
             self.sample(simdata.arbor_sim, probe_id) for probe_id in self._probe_ids
         ]

--- a/bsb_arbor/devices/probe.py
+++ b/bsb_arbor/devices/probe.py
@@ -22,8 +22,8 @@ class Probe(ArborDevice):
         kwargs = dict((k, getattr(self, k)) for k in probe_args if hasattr(self, k))
         return [getattr(arbor, self.get_probe_name())(**kwargs)]
 
-    def prepare_samples(self, sim):
-        super().prepare_samples(sim)
+    def prepare_samples(self, sim, comm):
+        super().prepare_samples(sim, comm)
         for probe_id, handle in zip(self._probe_ids, self._handles):
             self.adapter.result.add(ProbeRecorder(self, sim, probe_id, handle))
 

--- a/bsb_arbor/devices/spike_recorder.py
+++ b/bsb_arbor/devices/spike_recorder.py
@@ -25,7 +25,7 @@ class SpikeRecorder(ArborDevice, classmap_entry="spike_recorder"):
                     neo.SpikeTrain(
                         spiketrain,
                         units="ms",
-                        senders=senders,
+                        array_annotations={"senders": senders},
                         t_stop=self.simulation.duration,
                         device=self.name,
                         gids=list(self._gids),

--- a/bsb_arbor/devices/spike_recorder.py
+++ b/bsb_arbor/devices/spike_recorder.py
@@ -1,6 +1,5 @@
 import neo
 from bsb import config
-from bsb.services import MPI
 
 from ..device import ArborDevice
 
@@ -10,9 +9,9 @@ class SpikeRecorder(ArborDevice, classmap_entry="spike_recorder"):
     def boot(self):
         self._gids = set()
 
-    def prepare_samples(self, simdata):
-        super().prepare_samples(simdata)
-        if not MPI.get_rank():
+    def prepare_samples(self, simdata, comm):
+        super().prepare_samples(simdata, comm)
+        if not comm.get_rank():
 
             def record_device_spikes(segment):
                 spiketrain = list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dev = [
     "build~=1.0",
     "twine~=4.0",
     "pre-commit~=3.5",
-    "black~=24.1.1",
-    "isort~=5.12",
+    "black~=25.1.0",
+    "isort~=6.0.0",
     "snakeviz~=2.1",
     "bump-my-version~=0.24"
 ]


### PR DESCRIPTION
## What has been done

- Bump isort and black to new versions
- Store spike senders in the `array_annotations` dictionary of `neo.SpikeTrain` to allow merging (see https://github.com/dbbs-lab/bsb-nest/issues/18)
- fix: simulation comm (https://github.com/dbbs-lab/bsb-arbor/pull/7)


Maybe it should be a be considered as a breaking change?